### PR TITLE
Refactor categories and remove legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,7 @@
       </div>
     </header>
 
-    <div class="legend" id="legend"></div>
-
-    <table class="grid" id="grid"></table>
+      <table class="grid" id="grid"></table>
   </div>
 
   <script src="data/chore-config.js"></script>

--- a/scripts/chore-chart.js
+++ b/scripts/chore-chart.js
@@ -75,33 +75,6 @@ function groupByCategory(chores) {
   return [...map.entries()].map(([category, items]) => ({ category, items }));
 }
 
-// ---------- Renderers ----------
-function renderLegend(cfg) {
-  const wrap = document.getElementById('legend');
-  wrap.innerHTML = '';
-  const entries = Object.entries(cfg.legend || {});
-  for (const [code, label] of entries) {
-    const el = document.createElement('div');
-    el.className = 'swatch';
-    const sample = document.createElement('span');
-    sample.className = code === 'NA' ? 'na-square' : 'box';
-    el.appendChild(sample);
-    const text = document.createElement('span');
-    text.textContent = `${code} — ${label}`;
-    el.appendChild(text);
-    wrap.appendChild(el);
-  }
-  const na = document.createElement('div');
-  na.className = 'swatch';
-  const naSq = document.createElement('span');
-  naSq.className = 'na-square';
-  na.appendChild(naSq);
-  const naTxt = document.createElement('span');
-  naTxt.textContent = 'N/A';
-  na.appendChild(naTxt);
-  wrap.appendChild(na);
-}
-
 function buildWeek(start) {
   const dates = Array.from({length:7}, (_,i)=> addDays(start, i));
   const cfg = loadConfig();
@@ -111,8 +84,6 @@ function buildWeek(start) {
   const range = `${fmtDate(dates[0])} – ${fmtDate(dates[6])}`;
   document.getElementById('daterange').textContent = `Week of ${fmtDate(dates[0])} (${range})`;
 
-  renderLegend(cfg);
-
   const tbl = document.getElementById('grid');
   tbl.innerHTML = '';
 
@@ -120,7 +91,6 @@ function buildWeek(start) {
   const thead = document.createElement('thead');
   const hr = document.createElement('tr');
 
-  const thCat = document.createElement('th'); thCat.className = 'col-category'; thCat.textContent = 'Category'; hr.appendChild(thCat);
   const thTask = document.createElement('th'); thTask.className = 'col-task'; thTask.textContent = 'Chore'; hr.appendChild(thTask);
 
   for (const d of dates) {
@@ -134,11 +104,26 @@ function buildWeek(start) {
   const tbody = document.createElement('tbody');
 
   grouped.forEach((grp, idx) => {
-    grp.items.forEach((chore, j) => {
-      const tr = document.createElement('tr');
-      if (j === 0) tr.classList.add('sep');
+    if (idx > 0) {
+      const spacer = document.createElement('tr');
+      const spTd = document.createElement('td');
+      spTd.className = 'spacer';
+      spTd.colSpan = dates.length + 1;
+      spacer.appendChild(spTd);
+      tbody.appendChild(spacer);
+    }
 
-      const tdCat = document.createElement('td'); tdCat.className = 'category'; tdCat.textContent = grp.category; tr.appendChild(tdCat);
+    const headingTr = document.createElement('tr');
+    const headingTd = document.createElement('td');
+    headingTd.className = 'category-heading';
+    headingTd.textContent = grp.category;
+    headingTd.colSpan = dates.length + 1;
+    headingTr.appendChild(headingTd);
+    tbody.appendChild(headingTr);
+
+    grp.items.forEach(chore => {
+      const tr = document.createElement('tr');
+
       const tdTask = document.createElement('td'); tdTask.className = 'task'; tdTask.textContent = chore.name; tr.appendChild(tdTask);
 
       dates.forEach(d => {

--- a/styles/chore-chart.css
+++ b/styles/chore-chart.css
@@ -17,30 +17,26 @@ h1 { font-size: 44pt; line-height: 1; margin: 0; font-weight: 800; letter-spacin
 button { font-size: 16pt; padding: 0.4rem 0.7rem; border-radius: 12px; border: 2px solid #111; background: #f7f7f7; cursor: pointer; }
 button:hover { background: #eee; }
 
-/* --- Legend --- */
-.legend { font-size: 16pt; display: flex; gap: 1.2rem; flex-wrap: wrap; }
-.legend .swatch { display: inline-flex; align-items: center; gap: 0.4rem; }
-.na-square { width: 28pt; height: 28pt; border: 2px solid #aaa; background: #e9e9e9; display: inline-block; }
-.box { width: 28pt; height: 28pt; border: 3px solid #111; display: inline-block; }
+  /* --- Check boxes --- */
+  .na-square { width: 28pt; height: 28pt; border: 2px solid #aaa; background: #e9e9e9; display: inline-block; }
+  .box { width: 28pt; height: 28pt; border: 3px solid #111; display: inline-block; }
 
-/* --- Table --- */
+  /* --- Table --- */
 .grid { width: 100%; border-collapse: collapse; table-layout: fixed; }
 .grid th, .grid td { border: 2px solid #000; }
 .grid thead th { font-size: 18pt; padding: 0.25in 0.15in; background: #f2f2f2; }
 .grid thead .dow { font-weight: 800; font-size: 20pt; display: block; }
 .grid thead .date { font-weight: 600; opacity: 0.9; font-size: 16pt; display: block; }
 
-.col-category { width: 16%; }
-.col-task { width: 24%; }
-.col-day { width: calc(60% / 7); }
+  .col-task { width: 40%; }
+  .col-day { width: calc(60% / 7); }
 
-.category { font-size: 22pt; font-weight: 800; padding: 0.2in 0.15in; background: #fafafa; }
-.task { font-size: 20pt; font-weight: 600; padding: 0.18in 0.12in; }
+  .category-heading { font-size: 22pt; font-weight: 800; padding: 0.2in 0.15in; background: #fafafa; }
+  .spacer { height: 0.15in; border: none; }
+  .task { font-size: 20pt; font-weight: 600; padding: 0.18in 0.12in; }
 .cell { height: 34pt; text-align: center; }
 .cell > .box, .cell > .na-square { vertical-align: middle; }
 
-/* thicker separators between categories */
-.sep { border-top: 6px solid #000 !important; }
 
 /* Print optimizations */
 @media print {


### PR DESCRIPTION
## Summary
- Replace repeating category column with category heading rows and spacer rows between groups
- Drop chore frequency legend and associated rendering code
- Adjust layout styles for new heading rows and wider chore column

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afaceacd8483249286d96dcfa3b9e1