### PR TITLE
Scale chore chart to fit 12×18 page

### DIFF
--- a/scripts/chore-chart.js
+++ b/scripts/chore-chart.js
@@ -80,6 +80,10 @@ function buildWeek(start) {
   const cfg = loadConfig();
   const grouped = groupByCategory(cfg.chores);
 
+  // reset any previous scaling before rebuilding content
+  const container = document.querySelector('.container');
+  if (container) container.style.transform = '';
+
   // header range label
   const range = `${fmtDate(dates[0])} – ${fmtDate(dates[6])}`;
   document.getElementById('daterange').textContent = `Week of ${fmtDate(dates[0])} (${range})`;
@@ -144,6 +148,18 @@ function buildWeek(start) {
   tbl.appendChild(tbody);
 }
 
+// Scale the layout to ensure it fits within the printable 12×18in page
+function fitToPage() {
+  const container = document.querySelector('.container');
+  if (!container) return;
+
+  // printable height: page height minus 0.5in margins top/bottom
+  const printableHeightPx = (18 - 1) * 96; // 17in * 96 CSS px
+  const rect = container.getBoundingClientRect();
+  const scale = Math.min(printableHeightPx / rect.height, 1);
+  container.style.transform = scale < 1 ? `scale(${scale})` : '';
+}
+
 // ---------- Init & controls ----------
 function init() {
   const prevBtn = document.getElementById('prevSundayBtn');
@@ -153,6 +169,12 @@ function init() {
   prevBtn.addEventListener('click', () => buildWeek(startOfPreviousSunday(new Date())));
   nextBtn.addEventListener('click', () => buildWeek(startOfNextSunday(new Date())));
   printBtn.addEventListener('click', () => window.print());
+
+  window.addEventListener('beforeprint', fitToPage);
+  window.addEventListener('afterprint', () => {
+    const container = document.querySelector('.container');
+    if (container) container.style.transform = '';
+  });
 
   // Prompt-like default build: show both options; do nothing until user clicks.
   // For convenience, if you want an automatic default, uncomment one of these:

--- a/styles/chore-chart.css
+++ b/styles/chore-chart.css
@@ -9,7 +9,16 @@ body {
 }
 
 /* --- Layout --- */
-.container { padding: 0.25in; display: flex; flex-direction: column; gap: 0.25in; }
+.container {
+  width: 11in;
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 0.25in;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25in;
+  transform-origin: top left;
+}
 header { display: flex; justify-content: space-between; align-items: flex-end; gap: 1rem; }
 h1 { font-size: 44pt; line-height: 1; margin: 0; font-weight: 800; letter-spacing: -0.5px; }
 .daterange { font-size: 20pt; font-weight: 600; opacity: 0.85; }
@@ -42,5 +51,9 @@ button:hover { background: #eee; }
 @media print {
   .controls { display: none; }
   button { display: none; }
-  .container { padding: 0; }
+  .container {
+    margin: 0;
+    padding: 0;
+    width: 11in;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure chore chart container matches printable area and centers on screen
- scale layout before printing so full grid fits on a single 12×18 sheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afaea942348324a7c4bcf415ed8814