### PR TITLE
Adjust width to maintain aspect ratio and simplify printing

### DIFF
--- a/scripts/chore-chart.js
+++ b/scripts/chore-chart.js
@@ -80,12 +80,10 @@ function buildWeek(start) {
   const cfg = loadConfig();
   const grouped = groupByCategory(cfg.chores);
 
-  // reset any previous scaling before rebuilding content
+  // reset width before rebuilding content so measurements are accurate
   const container = document.querySelector('.container');
   if (container) {
-    container.style.transform = '';
     container.style.width = '';
-    container.style.height = '';
   }
 
   // header range label
@@ -151,38 +149,20 @@ function buildWeek(start) {
   tbl.appendChild(thead);
   tbl.appendChild(tbody);
 
-  // apply initial scaling so freshly built content fits the target page
-  fitToPage();
+  // adjust width to maintain the 12×18 aspect ratio based on content height
+  adjustWidthToAspect();
 }
 
-// Scale the layout to ensure it fits within the printable 12×18in page
-function getPageLengthInches() {
-  const container = document.querySelector('.container');
-  if (!container) return 0;
-  const rect = container.getBoundingClientRect();
-  return rect.height / 96; // convert px to inches
-}
-
-// Scale the layout so the total height does not exceed 18 inches
-function fitToPage() {
+// Adjust the container width to keep a 12×18 (2:3) aspect ratio
+function adjustWidthToAspect() {
   const container = document.querySelector('.container');
   if (!container) return;
 
-  const heightInches = getPageLengthInches();
+  // Clear width to measure the natural height
+  container.style.width = '';
   const rect = container.getBoundingClientRect();
-  const maxHeightInches = 18;
-
-  if (heightInches > maxHeightInches) {
-    const scale = maxHeightInches / heightInches;
-    container.style.transformOrigin = 'top left';
-    container.style.transform = `scale(${scale})`;
-    container.style.width = `${rect.width * scale}px`;
-    container.style.height = `${rect.height * scale}px`;
-  } else {
-    container.style.transform = '';
-    container.style.width = '';
-    container.style.height = '';
-  }
+  const newWidth = rect.height * (12 / 18);
+  container.style.width = `${newWidth}px`;
 }
 
 // ---------- Init & controls ----------
@@ -194,18 +174,7 @@ function init() {
   prevBtn.addEventListener('click', () => buildWeek(startOfPreviousSunday(new Date())));
   nextBtn.addEventListener('click', () => buildWeek(startOfNextSunday(new Date())));
   printBtn.addEventListener('click', () => {
-    fitToPage();
     window.print();
-  });
-
-  window.addEventListener('beforeprint', fitToPage);
-  window.addEventListener('afterprint', () => {
-    const container = document.querySelector('.container');
-    if (container) {
-      container.style.transform = '';
-      container.style.width = '';
-      container.style.height = '';
-    }
   });
 
   // Prompt-like default build: show both options; do nothing until user clicks.

--- a/styles/chore-chart.css
+++ b/styles/chore-chart.css
@@ -10,14 +10,13 @@ body {
 
 /* --- Layout --- */
 .container {
-  width: 11in;
+  width: 100%;
   box-sizing: border-box;
   margin: 0 auto;
   padding: 0.25in;
   display: flex;
   flex-direction: column;
   gap: 0.25in;
-  transform-origin: top left;
 }
 header { display: flex; justify-content: space-between; align-items: flex-end; gap: 1rem; }
 h1 { font-size: 44pt; line-height: 1; margin: 0; font-weight: 800; letter-spacing: -0.5px; }
@@ -27,8 +26,13 @@ button { font-size: 16pt; padding: 0.4rem 0.7rem; border-radius: 12px; border: 2
 button:hover { background: #eee; }
 
   /* --- Check boxes --- */
-  .na-square { width: 28pt; height: 28pt; border: 2px solid #aaa; background: #e9e9e9; display: inline-block; }
-  .box { width: 28pt; height: 28pt; border: 3px solid #111; display: inline-block; }
+  .na-square, .box {
+    width: 80%;
+    aspect-ratio: 1 / 1;
+    display: inline-block;
+  }
+  .na-square { border: 2px solid #aaa; background: #e9e9e9; }
+  .box { border: 3px solid #111; }
 
   /* --- Table --- */
 .grid { width: 100%; border-collapse: collapse; table-layout: fixed; }
@@ -43,8 +47,8 @@ button:hover { background: #eee; }
   .category-heading { font-size: 22pt; font-weight: 800; padding: 0.2in 0.15in; background: #fafafa; }
   .spacer { height: 0.15in; border: none; }
   .task { font-size: 20pt; font-weight: 600; padding: 0.18in 0.12in; }
-.cell { height: 34pt; text-align: center; }
-.cell > .box, .cell > .na-square { vertical-align: middle; }
+  .cell { text-align: center; }
+  .cell > .box, .cell > .na-square { vertical-align: middle; }
 
 
 /* Print optimizations */
@@ -54,6 +58,6 @@ button:hover { background: #eee; }
   .container {
     margin: 0;
     padding: 0;
-    width: 11in;
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- Replace height-based scaling with `adjustWidthToAspect` to set container width based on content height.
- Remove print scaling logic so the page prints exactly as displayed.
- Use percentage sizing for container and checkboxes so the layout scales automatically.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afb79f4a4483248844a54a0a0d41bd