### PR TITLE
Remove fixed sizing for flexible chore chart prints

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Chore Chart Generator (12×18 print)</title>
+  <title>Chore Chart Generator</title>
   <link rel="stylesheet" href="styles/chore-chart.css">
 </head>
 <body>

--- a/scripts/chore-chart.js
+++ b/scripts/chore-chart.js
@@ -80,12 +80,6 @@ function buildWeek(start) {
   const cfg = loadConfig();
   const grouped = groupByCategory(cfg.chores);
 
-  // reset width before rebuilding content so measurements are accurate
-  const container = document.querySelector('.container');
-  if (container) {
-    container.style.width = '';
-  }
-
   // header range label
   const range = `${fmtDate(dates[0])} – ${fmtDate(dates[6])}`;
   document.getElementById('daterange').textContent = `Week of ${fmtDate(dates[0])} (${range})`;
@@ -149,20 +143,6 @@ function buildWeek(start) {
   tbl.appendChild(thead);
   tbl.appendChild(tbody);
 
-  // adjust width to maintain the 12×18 aspect ratio based on content height
-  adjustWidthToAspect();
-}
-
-// Adjust the container width to keep a 12×18 (2:3) aspect ratio
-function adjustWidthToAspect() {
-  const container = document.querySelector('.container');
-  if (!container) return;
-
-  // Clear width to measure the natural height
-  container.style.width = '';
-  const rect = container.getBoundingClientRect();
-  const newWidth = rect.height * (12 / 18);
-  container.style.width = `${newWidth}px`;
 }
 
 // ---------- Init & controls ----------

--- a/styles/chore-chart.css
+++ b/styles/chore-chart.css
@@ -1,5 +1,4 @@
 /* --- Print sizing --- */
-@page { size: 12in 18in; margin: 0.5in; }
 html, body { height: 100%; }
 body {
   font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
@@ -13,40 +12,40 @@ body {
   width: 100%;
   box-sizing: border-box;
   margin: 0 auto;
-  padding: 0.25in;
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25in;
+  gap: 1.5rem;
 }
 header { display: flex; justify-content: space-between; align-items: flex-end; gap: 1rem; }
-h1 { font-size: 44pt; line-height: 1; margin: 0; font-weight: 800; letter-spacing: -0.5px; }
-.daterange { font-size: 20pt; font-weight: 600; opacity: 0.85; }
+h1 { font-size: 3.5rem; line-height: 1; margin: 0; font-weight: 800; letter-spacing: -0.03125rem; }
+.daterange { font-size: 1.25rem; font-weight: 600; opacity: 0.85; }
 .controls { display: flex; gap: 0.5rem; flex-wrap: wrap; }
-button { font-size: 16pt; padding: 0.4rem 0.7rem; border-radius: 12px; border: 2px solid #111; background: #f7f7f7; cursor: pointer; }
+button { font-size: 1rem; padding: 0.4rem 0.7rem; border-radius: 0.75rem; border: 0.125rem solid #111; background: #f7f7f7; cursor: pointer; }
 button:hover { background: #eee; }
 
   /* --- Check boxes --- */
   .na-square, .box {
-    width: 80%;
+    width: 1.2em;
     aspect-ratio: 1 / 1;
     display: inline-block;
   }
-  .na-square { border: 2px solid #aaa; background: #e9e9e9; }
-  .box { border: 3px solid #111; }
+  .na-square { border: 0.125rem solid #aaa; background: #e9e9e9; }
+  .box { border: 0.1875rem solid #111; }
 
   /* --- Table --- */
 .grid { width: 100%; border-collapse: collapse; table-layout: fixed; }
-.grid th, .grid td { border: 2px solid #000; }
-.grid thead th { font-size: 18pt; padding: 0.25in 0.15in; background: #f2f2f2; }
-.grid thead .dow { font-weight: 800; font-size: 20pt; display: block; }
-.grid thead .date { font-weight: 600; opacity: 0.9; font-size: 16pt; display: block; }
+.grid th, .grid td { border: 0.125rem solid #000; }
+.grid thead th { font-size: 1.125rem; padding: 1.5rem 0.9rem; background: #f2f2f2; }
+.grid thead .dow { font-weight: 800; font-size: 1.25rem; display: block; }
+.grid thead .date { font-weight: 600; opacity: 0.9; font-size: 1rem; display: block; }
 
   .col-task { width: 40%; }
   .col-day { width: calc(60% / 7); }
 
-  .category-heading { font-size: 22pt; font-weight: 800; padding: 0.2in 0.15in; background: #fafafa; }
-  .spacer { height: 0.15in; border: none; }
-  .task { font-size: 20pt; font-weight: 600; padding: 0.18in 0.12in; }
+  .category-heading { font-size: 1.375rem; font-weight: 800; padding: 1.2rem 0.9rem; background: #fafafa; }
+  .spacer { height: 0.9rem; border: none; }
+  .task { font-size: 1.25rem; font-weight: 600; padding: 1.08rem 0.72rem; }
   .cell { text-align: center; }
   .cell > .box, .cell > .na-square { vertical-align: middle; }
 


### PR DESCRIPTION
## Summary
- replace hard-coded inch/point measurements with rem and em units
- enlarge check boxes using em sizing and simplify print CSS
- drop 12×18 aspect-ratio script and update page title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afbae750948324af41e4cf512c90c2